### PR TITLE
ci: build and publish u-boot artifacts to OpenIPC/firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,12 @@ jobs:
           name: u-boot-${{ matrix.soc }}-universal
           path: u-boot-${{ matrix.soc }}-universal.bin
 
+  # No qemu_smoke job for this repo: widgetii/qemu-hisilicon's
+  # hi3516av100 machine doesn't currently support u-boot flash boot
+  # (the UART produces only padding when u-boot runs). Add a smoke
+  # job once that lands. Linux-direct-kernel boot in qemu does work,
+  # so this is purely a u-boot-on-av100 emulation gap.
+
   # Publish job — common failure modes:
   #   "GH_TOKEN environment variable required" / empty token: secret
   #     FIRMWARE_RELEASE_TOKEN is missing or unreadable. Set via the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,115 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { soc: hi3516av100, short: hi3516a }
+          - { soc: hi3516dv100, short: hi3516d }
+
+    steps:
+      - name: Install 32-bit libs
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq zlib1g:i386 libc6:i386 libstdc++6:i386
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache toolchain
+        id: cache-tc
+        uses: actions/cache@v4
+        with:
+          path: toolchain
+          key: arm-hisiv510-linux-v1
+
+      - name: Download toolchain
+        if: steps.cache-tc.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v1 -R OpenIPC/toolchains \
+            -p 'arm-hisiv510-linux.tgz'
+          mkdir -p toolchain
+          tar xzf arm-hisiv510-linux.tgz -C toolchain
+          if [ -f toolchain/arm-hisiv510-linux/arm-hisiv510-linux.tar.bz2 ]; then
+            tar xjf toolchain/arm-hisiv510-linux/arm-hisiv510-linux.tar.bz2 -C toolchain
+          fi
+          rm arm-hisiv510-linux.tgz
+          # Create short-name symlinks (target/bin/ has absolute symlinks that won't work)
+          cd toolchain/arm-hisiv510-linux/bin
+          for f in arm-hisiv510-linux-uclibcgnueabi-*; do
+            ln -sf "$f" "${f/-uclibcgnueabi/}"
+          done
+
+      - name: Build
+        run: |
+          export PATH="$PWD/toolchain/arm-hisiv510-linux/bin:$PATH"
+          # Both SoCs share the hi3516a board config; build.sh patches
+          # the header to swap the SoC tag. Replicate that here.
+          sed -i "s/hi3516.v100/${{ matrix.soc }}/" include/configs/hi3516a.h
+          make hi3516a_config
+          cp reg_info_${{ matrix.short }}.bin .reg
+          make CROSS_COMPILE=arm-hisiv510-linux- -j$(nproc)
+          make CROSS_COMPILE=arm-hisiv510-linux- mini-boot.bin
+          cp mini-boot.bin u-boot-${{ matrix.soc }}-universal.bin
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: u-boot-${{ matrix.soc }}-universal
+          path: u-boot-${{ matrix.soc }}-universal.bin
+
+  # Publish job — common failure modes:
+  #   "GH_TOKEN environment variable required" / empty token: secret
+  #     FIRMWARE_RELEASE_TOKEN is missing or unreadable. Set via the
+  #     org-level Actions secret on OpenIPC.
+  #   401 Bad credentials: PAT expired (fine-grained max is 1 year) or
+  #     revoked. Mint a new fine-grained PAT and update the secret.
+  #   403 Forbidden: PAT lacks Contents:write on OpenIPC/firmware, or
+  #     its repo selector doesn't include OpenIPC/firmware.
+  #   404 on `gh release upload latest`: the `latest` tag was deleted in
+  #     OpenIPC/firmware. Recreate it before retrying.
+  publish:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Upload to OpenIPC/firmware latest release
+        env:
+          GH_TOKEN: ${{ secrets.FIRMWARE_RELEASE_TOKEN }}
+        run: |
+          set -eu
+          # Releases API occasionally returns 502/503 ("Unicorn!"). Retry
+          # with linear backoff: 10s, 20s, 30s, 40s — total ~100s.
+          upload() {
+            local f="$1" i
+            for i in 1 2 3 4 5; do
+              if gh release upload latest "$f" --clobber -R OpenIPC/firmware; then
+                return 0
+              fi
+              [ "$i" = "5" ] && return 1
+              echo "upload attempt $i failed; sleeping $((i*10))s" >&2
+              sleep $((i*10))
+            done
+          }
+          for soc in hi3516av100 hi3516dv100; do
+            f="artifacts/u-boot-${soc}-universal/u-boot-${soc}-universal.bin"
+            test -f "$f"
+            upload "$f"
+          done


### PR DESCRIPTION
Mirrors OpenIPC/u-boot-hi3519v101's CI: per-SoC matrix (hi3516av100, hi3516dv100), cached arm-hisiv510-linux toolchain from OpenIPC/toolchains v1, and a publish job that uploads u-boot-<soc>-universal.bin to 'latest' in OpenIPC/firmware on push to master.

build.sh's per-SoC sed-patch on include/configs/hi3516a.h is replicated inside the matrix step. The two SoCs share the same board config, so the matrix entry pairs each long SoC name with its short reg_info prefix.

Requires the org-level FIRMWARE_RELEASE_TOKEN secret to publish on merge.
