### PR TITLE
ci: link av100 qemu_smoke gap to widgetii/qemu-hisilicon#59

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,11 @@ jobs:
 
   # No qemu_smoke job for this repo: widgetii/qemu-hisilicon's
   # hi3516av100 machine doesn't currently support u-boot flash boot
-  # (the UART produces only padding when u-boot runs). Add a smoke
-  # job once that lands. Linux-direct-kernel boot in qemu does work,
-  # so this is purely a u-boot-on-av100 emulation gap.
+  # (the UART produces only padding when u-boot runs). Linux-direct-
+  # kernel boot in qemu does work, so this is purely a u-boot-on-av100
+  # emulation gap. Add a smoke job once
+  #   https://github.com/widgetii/qemu-hisilicon/issues/59
+  # is closed.
 
   # Publish job — common failure modes:
   #   "GH_TOKEN environment variable required" / empty token: secret


### PR DESCRIPTION
Adds the issue link to the workflow comment that explains why this repo's CI doesn't have a qemu_smoke gate. Issue: https://github.com/widgetii/qemu-hisilicon/issues/59