### PR TITLE
ci: gate publish on u-boot fitting 256 KiB boot partition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,21 @@ jobs:
           make CROSS_COMPILE=arm-hisiv510-linux- mini-boot.bin
           cp mini-boot.bin u-boot-${{ matrix.soc }}-universal.bin
 
+      - name: Check partition fit
+        run: |
+          # The boot partition in mtdparts (hi-common.h) is 256 KiB
+          # across every NOR/NAND/UBI variant. Anything past that
+          # overflows into env at offset 0x40000 and bricks the device
+          # on upgrade. Mirrors OpenIPC/firmware Makefile CHECK_SIZE.
+          FILE=u-boot-${{ matrix.soc }}-universal.bin
+          LIMIT_KB=256
+          SIZE_KB=$(($(stat -c %s "$FILE") / 1024))
+          echo "- $FILE: [${SIZE_KB}KB/${LIMIT_KB}KB]"
+          if [ "$SIZE_KB" -gt "$LIMIT_KB" ]; then
+            echo "-- size exceeded by: $((SIZE_KB - LIMIT_KB))KB"
+            exit 1
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Adds a `Check partition fit` step to the build job that fails CI
if `u-boot-<soc>-universal.bin` exceeds 256 KiB — the size of
the `(boot)` partition declared in `include/configs/hi-common.h`
across every NOR/NAND/UBI mtdparts variant.

Mirrors `OpenIPC/firmware/Makefile` `CHECK_SIZE` macro (lines
155–161) which already gates kernel/rootfs sizes against per-SoC
flash limits. Without this, a future feature merge could push
u-boot past 256 KiB, the publish job would happily upload it, and
the next user upgrade would overflow into env at offset 0x40000
and brick the device.

All current binaries fit well under the limit — this lands as
a preventive guard.

## Test plan

- [ ] CI `Check partition fit` step runs green on every matrix
      entry with output like `- u-boot-<soc>-universal.bin:
      [<size>KB/256KB]`.
- [ ] All other jobs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)