### PR TITLE
ci: gate hi3516av100 publish on QEMU smoke (qemu#59 closed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,13 +85,83 @@ jobs:
           name: u-boot-${{ matrix.soc }}-universal
           path: u-boot-${{ matrix.soc }}-universal.bin
 
-  # No qemu_smoke job for this repo: widgetii/qemu-hisilicon's
-  # hi3516av100 machine doesn't currently support u-boot flash boot
-  # (the UART produces only padding when u-boot runs). Linux-direct-
-  # kernel boot in qemu does work, so this is purely a u-boot-on-av100
-  # emulation gap. Add a smoke job once
-  #   https://github.com/widgetii/qemu-hisilicon/issues/59
-  # is closed.
+  qemu_smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # widgetii/qemu-hisilicon#59 (av100 u-boot UART padding) is
+        # closed, so the hi3516av100 machine boots our u-boot now.
+        # hi3516dv100 has no QEMU machine in qemu-hisilicon and
+        # publishes unguarded.
+        include:
+          - { soc: hi3516av100, machine: hi3516av100 }
+    steps:
+      - name: Install QEMU build deps
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends \
+            build-essential ninja-build meson pkg-config \
+            libglib2.0-dev libpixman-1-dev libfdt-dev zlib1g-dev \
+            libslirp-dev python3 python3-venv
+
+      - name: Resolve qemu-hisilicon HEAD
+        id: qemu-rev
+        run: |
+          sha=$(git ls-remote https://github.com/widgetii/qemu-hisilicon master | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Cache qemu-system-arm
+        id: cache-qemu
+        uses: actions/cache@v4
+        with:
+          path: qemu-arm
+          key: qemu-hisilicon-${{ steps.qemu-rev.outputs.sha }}
+
+      - name: Build qemu-system-arm (cache miss)
+        if: steps.cache-qemu.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth 1 --branch master \
+            https://github.com/widgetii/qemu-hisilicon qemu-hisilicon
+          cd qemu-hisilicon
+          bash qemu/setup.sh
+          cp qemu-src/build/qemu-system-arm "$GITHUB_WORKSPACE/qemu-arm"
+          chmod +x "$GITHUB_WORKSPACE/qemu-arm"
+
+      - name: Download u-boot artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: u-boot-${{ matrix.soc }}-universal
+
+      - name: Smoke-test in QEMU
+        timeout-minutes: 2
+        run: |
+          UBOOT="$PWD/u-boot-${{ matrix.soc }}-universal.bin"
+          test -f "$UBOOT"
+          dd if=/dev/zero of=/tmp/flash.bin bs=1M count=8 2>/dev/null
+          dd if="$UBOOT" of=/tmp/flash.bin bs=1 conv=notrunc 2>/dev/null
+          mkfifo /tmp/uart.in /tmp/uart.out
+          chmod +x ./qemu-arm
+          ./qemu-arm \
+            -M ${{ matrix.machine }} \
+            -global hisi-fmc.flash-file=/tmp/flash.bin \
+            -nographic -serial pipe:/tmp/uart \
+            -monitor none > /tmp/qemu.log 2>&1 &
+          QEMU_PID=$!
+          timeout 10 cat /tmp/uart.out > /tmp/uboot.txt || true
+          kill "$QEMU_PID" 2>/dev/null || true
+          wait 2>/dev/null || true
+          echo "== captured u-boot output =="
+          cat /tmp/uboot.txt
+          echo
+          if grep -qE 'U-Boot |Hit any key|CPU:|DRAM:|Board:' /tmp/uboot.txt; then
+            echo "PASS: u-boot booted past System startup"
+          else
+            echo "FAIL: u-boot did not get past System startup"
+            tail -40 /tmp/qemu.log || true
+            exit 1
+          fi
 
   # Publish job — common failure modes:
   #   "GH_TOKEN environment variable required" / empty token: secret
@@ -104,7 +174,7 @@ jobs:
   #   404 on `gh release upload latest`: the `latest` tag was deleted in
   #     OpenIPC/firmware. Recreate it before retrying.
   publish:
-    needs: build
+    needs: [build, qemu_smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,11 +92,14 @@ jobs:
       fail-fast: false
       matrix:
         # widgetii/qemu-hisilicon#59 (av100 u-boot UART padding) is
-        # closed, so the hi3516av100 machine boots our u-boot now.
+        # closed. AV100 (V2A) shares CV100's HISFC350 flash controller,
+        # so the smoke test must use `-global hisi-sfc350.flash-file=`
+        # rather than the more common `hisi-fmc.flash-file=` — same as
+        # the u-boot-hi3516cv100 sibling workflow.
         # hi3516dv100 has no QEMU machine in qemu-hisilicon and
         # publishes unguarded.
         include:
-          - { soc: hi3516av100, machine: hi3516av100 }
+          - { soc: hi3516av100, machine: hi3516av100, flash_type: hisi-sfc350 }
     steps:
       - name: Install QEMU build deps
         run: |
@@ -145,7 +148,7 @@ jobs:
           chmod +x ./qemu-arm
           ./qemu-arm \
             -M ${{ matrix.machine }} \
-            -global hisi-fmc.flash-file=/tmp/flash.bin \
+            -global ${{ matrix.flash_type }}.flash-file=/tmp/flash.bin \
             -nographic -serial pipe:/tmp/uart \
             -monitor none > /tmp/qemu.log 2>&1 &
           QEMU_PID=$!


### PR DESCRIPTION
## Summary

widgetii/qemu-hisilicon#59 closed today — the hi3516av100 machine
now boots our u-boot binary instead of producing only UART
padding. Add the standard qemu_smoke job (mirrors cv300/cv500/ev200/
gk siblings) and require it for publish.

`hi3516dv100` has no QEMU machine in qemu-hisilicon and continues
to publish unguarded.

## Test plan

- [ ] CI `qemu_smoke (hi3516av100, hi3516av100)` job passes — UART
      output contains `U-Boot|Hit any key|CPU:|DRAM:|Board:`.
- [ ] Publish job's `needs:` now includes qemu_smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)