### PR TITLE
ci: add hi3516dv100 qemu_smoke (qemu-hisilicon#77 landed)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,15 +91,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # widgetii/qemu-hisilicon#59 (av100 u-boot UART padding) is
-        # closed. AV100 (V2A) shares CV100's HISFC350 flash controller,
-        # so the smoke test must use `-global hisi-sfc350.flash-file=`
+        # Both V2A SoCs share CV100's HISFC350 flash controller, so
+        # the smoke test must use `-global hisi-sfc350.flash-file=`
         # rather than the more common `hisi-fmc.flash-file=` — same as
-        # the u-boot-hi3516cv100 sibling workflow.
-        # hi3516dv100 has no QEMU machine in qemu-hisilicon and
-        # publishes unguarded.
+        # the u-boot-hi3516cv100 sibling workflow. hi3516dv100 was
+        # added to qemu-hisilicon in #77 (V2A, die-identical to av100).
         include:
           - { soc: hi3516av100, machine: hi3516av100, flash_type: hisi-sfc350 }
+          - { soc: hi3516dv100, machine: hi3516dv100, flash_type: hisi-sfc350 }
     steps:
       - name: Install QEMU build deps
         run: |


### PR DESCRIPTION
## Summary

widgetii/qemu-hisilicon#77 added the `hi3516dv100` machine type
as a verbatim clone of `hi3516av100` (V2A, die-identical silicon
per ipctool's chip-id table — DV100 is just chip_variant=2 of
the same die).

Wires `hi3516dv100` into the qemu_smoke matrix; both V2A SoCs
use `-global hisi-sfc350.flash-file=...` (HISFC350 flash
controller, same as cv100).

## Test plan

- [ ] CI `qemu_smoke (hi3516dv100, hi3516dv100, hisi-sfc350)`
      passes — UART output contains `U-Boot|Hit any key|CPU:|DRAM:`.
- [ ] Existing `hi3516av100` smoke still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)